### PR TITLE
Improve preview handling and add progress feedback

### DIFF
--- a/pysteam/bsp/preview.py
+++ b/pysteam/bsp/preview.py
@@ -59,7 +59,10 @@ class BSPViewWidget(QWidget):
         try:
             bsp = bsp_tool.load_bsp(tmp_path)
         finally:
-            os.unlink(tmp_path)
+            try:
+                os.unlink(tmp_path)
+            except PermissionError:
+                pass
 
         # Gather geometry as a list of polygons, each polygon being a sequence
         # of ``(x, y)`` tuples.  The logic mirrors the approach used by both

--- a/pysteam/mdl/preview.py
+++ b/pysteam/mdl/preview.py
@@ -90,8 +90,11 @@ class MDLViewWidget(QWidget):
         """Return bounding box for a Source engine model."""
 
         # Offsets taken from ``studiohdr_t`` in the Source SDK.
-        if len(data) < 152:
+        # Some models store a zero-sized bounding box at the later offsets,
+        # so fall back to the hull bounds which are populated for most
+        # compiled models.
+        if len(data) < 144:
             return None
-        bbmin = struct.unpack_from("<3f", data, 128)
-        bbmax = struct.unpack_from("<3f", data, 140)
+        bbmin = struct.unpack_from("<3f", data, 96)
+        bbmax = struct.unpack_from("<3f", data, 108)
         return bbmin, bbmax


### PR DESCRIPTION
## Summary
- add standalone preview dialog with console log pane
- fix icon and model previews and safe BSP temp cleanup
- show progress dialogs for validation, conversion and defragmentation
- port HLLib defragmentation and validation logic for accurate block handling

## Testing
- `python -m py_compile gcfscape_gui.py pysteam/bsp/preview.py pysteam/fs/cachefile.py pysteam/mdl/preview.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdc00994c48330ab9c25d37e8be52d