### PR TITLE
Improve preview widgets and explorer interactions

### DIFF
--- a/pysteam/bsp/preview.py
+++ b/pysteam/bsp/preview.py
@@ -16,13 +16,22 @@ from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
 
 from . import detect_engine
 
+# ``bsp_tool``/``pyqtgraph``/``numpy`` are optional dependencies used for the
+# interactive 3D preview.  Import them individually so we can provide more
+# helpful error messages when one is missing.
 try:  # pragma: no cover - optional dependencies
     import bsp_tool  # type: ignore
-    import numpy as np
-    import pyqtgraph.opengl as gl
 except Exception:  # pragma: no cover - missing optional deps
     bsp_tool = None  # type: ignore
+
+try:  # pragma: no cover - optional dependencies
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover - missing optional deps
     np = None  # type: ignore
+
+try:  # pragma: no cover - optional dependencies
+    import pyqtgraph.opengl as gl  # type: ignore
+except Exception:  # pragma: no cover - missing optional deps
     gl = None  # type: ignore
 
 
@@ -53,9 +62,17 @@ class BSPViewWidget(QWidget):
     def load_map(self, data: bytes) -> None:
         """Render ``data`` representing a BSP file into the widget."""
 
-        if not (bsp_tool and gl and np):
+        if not bsp_tool:
             if isinstance(self.view, QLabel):
-                self.view.setText("bsp_tool or pyqtgraph missing")
+                self.view.setText("bsp_tool module missing")
+            return
+        if not gl:
+            if isinstance(self.view, QLabel):
+                self.view.setText("pyqtgraph module missing")
+            return
+        if not np:
+            if isinstance(self.view, QLabel):
+                self.view.setText("numpy module missing")
             return
 
         self.clear()

--- a/pysteam/fs/cachefile.py
+++ b/pysteam/fs/cachefile.py
@@ -263,9 +263,27 @@ class CacheFile:
         if target_version not in (1, 3, 5, 6):
             raise ValueError("Unsupported GCF version: %d" % target_version)
 
+        header_owner = self.header.owner
+        self.header.owner = None
+        bem_owner = self.block_entry_map.owner if self.block_entry_map else None
+        if self.block_entry_map:
+            self.block_entry_map.owner = None
+        manifest_owner = self.manifest.owner
+        self.manifest.owner = None
+
         header = copy.deepcopy(self.header)
         block_entry_map = copy.deepcopy(self.block_entry_map)
         manifest = copy.deepcopy(self.manifest)
+
+        self.header.owner = header_owner
+        if self.block_entry_map:
+            self.block_entry_map.owner = bem_owner
+        self.manifest.owner = manifest_owner
+
+        header.owner = None
+        if block_entry_map:
+            block_entry_map.owner = None
+        manifest.owner = None
 
         header.format_version = target_version
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 PyQt5>=5.15
 bsp_tool>=0.5
 Pillow>=9
+numpy>=1.21
+pyqtgraph>=0.13
+PyOpenGL>=3.1


### PR DESCRIPTION
## Summary
- refine BSP preview dependency checks with clearer error messages
- replace 2D MDL preview with pyqtgraph-based 3D bounding box renderer
- declare numpy, pyqtgraph, and PyOpenGL in requirements
- add status bar fields with separators, grid layout for icon views, and type column secondary sorting
- fix GCF v1 conversion by avoiding pickling file handles
- cache entered decryption keys to avoid repeated prompts when opening encrypted files

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bde8b1a3988330ae2bb20462847ed9