### PR TITLE
Improve BSP preview dependency handling

### DIFF
--- a/pysteam/bsp/preview.py
+++ b/pysteam/bsp/preview.py
@@ -31,8 +31,15 @@ except Exception:  # pragma: no cover - missing optional deps
 
 try:  # pragma: no cover - optional dependencies
     import pyqtgraph.opengl as gl  # type: ignore
+    _gl_missing_dep: str | None = None
+except ModuleNotFoundError as exc:  # pragma: no cover - missing optional deps
+    gl = None  # type: ignore
+    # ``pyqtgraph.opengl`` depends on ``PyOpenGL``.  Distinguish between the
+    # two so the user gets a helpful message about which package they need.
+    _gl_missing_dep = "PyOpenGL" if exc.name == "OpenGL" else "pyqtgraph"
 except Exception:  # pragma: no cover - missing optional deps
     gl = None  # type: ignore
+    _gl_missing_dep = "pyqtgraph"
 
 
 class BSPViewWidget(QWidget):
@@ -43,7 +50,8 @@ class BSPViewWidget(QWidget):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         if gl is None:
-            self.view: QWidget = QLabel("pyqtgraph module missing")
+            missing = _gl_missing_dep or "pyqtgraph"
+            self.view: QWidget = QLabel(f"{missing} module missing")
             layout.addWidget(self.view)
         else:
             self.view = gl.GLViewWidget()
@@ -68,7 +76,8 @@ class BSPViewWidget(QWidget):
             return
         if not gl:
             if isinstance(self.view, QLabel):
-                self.view.setText("pyqtgraph module missing")
+                missing = _gl_missing_dep or "pyqtgraph"
+                self.view.setText(f"{missing} module missing")
             return
         if not np:
             if isinstance(self.view, QLabel):


### PR DESCRIPTION
## Summary
- Handle missing PyOpenGL separately from pyqtgraph in BSP preview
- Display informative message for whichever dependency is absent

## Testing
- `python -m py_compile pysteam/bsp/preview.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68be0175853c833080252776d816e047